### PR TITLE
Add meeting recorder web application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.env
+.venv/
+data/recordings/
+data/results/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,88 @@
-# MeetingRecorder
-AI based meeting notes assistant
+# Meeting Recorder
 
-Python based application for recording, transcribing and summarizing meetings.
+A self-hosted meeting assistant that records audio, transcribes the conversation with
+speaker diarisation, generates summaries and action items using an LLM, and lets you
+export the results.
+
+## Features
+
+- Web UI for starting, pausing, resuming, and stopping audio recordings in the browser.
+- Transcription with speaker identification powered by [AssemblyAI](https://www.assemblyai.com/).
+- Meeting summary and action item extraction using [OpenAI](https://openai.com/) models.
+- Optional speaker relabelling directly in the UI.
+- Export meeting notes to disk or email them via SMTP.
+
+## Requirements
+
+- Python 3.10+
+- Node is **not** required; the UI is pure HTML/CSS/JavaScript served by Flask.
+- AssemblyAI and OpenAI API keys.
+- Optional SMTP credentials if you want to email meeting notes.
+
+## Quick start
+
+1. Create and activate a virtual environment.
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install dependencies.
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Export the required environment variables:
+
+   ```bash
+   export ASSEMBLYAI_API_KEY="<your-assemblyai-key>"
+   export OPENAI_API_KEY="<your-openai-key>"
+   # Optional overrides
+   export OPENAI_MODEL="gpt-4o-mini"
+   export EMAIL_ENABLED=true
+   export SMTP_SERVER="smtp.example.com"
+   export SMTP_PORT=587
+   export SMTP_USERNAME="bot@example.com"
+   export SMTP_PASSWORD="<smtp-password>"
+   export EMAIL_SENDER="bot@example.com"
+   export EMAIL_RECIPIENT="product@example.com"
+   ```
+
+   Omit the email-related settings if you do not need email delivery.
+
+4. Run the development server.
+
+   ```bash
+   flask --app app.main run --debug
+   ```
+
+   Visit <http://127.0.0.1:5000/> to open the interface. Grant the browser access to
+your microphone, record the meeting, and wait for the transcription and summary.
+
+5. Export the meeting results to disk or send them via email from the UI.
+
+## Testing
+
+Run the automated tests with `pytest`:
+
+```bash
+pytest
+```
+
+## Architecture overview
+
+- `app/main.py`: Flask application wiring, request handlers, and service composition.
+- `app/services/`: Service layer for transcription, LLM summarisation, formatting, and email.
+- `static/` and `templates/`: Front-end assets served by Flask.
+- `tests/`: Unit tests covering formatting helpers and the email sender.
+
+## Notes
+
+- The transcription and summarisation steps require internet access to reach AssemblyAI
+  and OpenAI.
+- Recordings are stored under `data/recordings/` and exported notes are saved under
+  `data/results/`.
+- When emailing results the SMTP server must support STARTTLS if `SMTP_USE_TLS` is left
+  at its default value of `true`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,19 @@
+"""Meeting recorder application package."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from flask import Flask
+
+
+def create_app() -> "Flask":
+    """Factory that defers importing Flask until needed."""
+
+    from .main import create_app as _create_app
+
+    return _create_app()
+
+
+__all__ = ["create_app"]

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,43 @@
+"""Application configuration utilities."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+def _bool_env(var_name: str, default: bool = False) -> bool:
+    """Return the boolean value of an environment variable."""
+    value = os.getenv(var_name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class EmailSettings:
+    """Configuration for the optional email integration."""
+
+    enabled: bool = field(default_factory=lambda: _bool_env("EMAIL_ENABLED", False))
+    smtp_server: Optional[str] = field(default_factory=lambda: os.getenv("SMTP_SERVER"))
+    smtp_port: int = field(default_factory=lambda: int(os.getenv("SMTP_PORT", "587")))
+    smtp_username: Optional[str] = field(default_factory=lambda: os.getenv("SMTP_USERNAME"))
+    smtp_password: Optional[str] = field(default_factory=lambda: os.getenv("SMTP_PASSWORD"))
+    use_tls: bool = field(default_factory=lambda: _bool_env("SMTP_USE_TLS", True))
+    default_sender: Optional[str] = field(default_factory=lambda: os.getenv("EMAIL_SENDER"))
+    default_recipient: Optional[str] = field(default_factory=lambda: os.getenv("EMAIL_RECIPIENT"))
+
+
+@dataclass
+class Settings:
+    """Container for configuration loaded from environment variables."""
+
+    assemblyai_api_key: Optional[str] = field(default_factory=lambda: os.getenv("ASSEMBLYAI_API_KEY"))
+    openai_api_key: Optional[str] = field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    openai_model: str = field(default_factory=lambda: os.getenv("OPENAI_MODEL", "gpt-4o-mini"))
+    email: EmailSettings = field(default_factory=EmailSettings)
+
+
+settings = Settings()
+
+__all__ = ["settings", "Settings", "EmailSettings"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,157 @@
+"""Flask application providing the meeting recorder API."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from flask import Flask, jsonify, render_template, request
+
+from .config import settings
+from .services.emailer import EmailNotConfiguredError, EmailSender
+from .services.formatter import build_result_document, format_transcript_text
+from .services.llm import LLMServiceError, OpenAILlmService
+from .services.transcription import (
+    AssemblyAITranscriptionService,
+    TranscriptionSegment,
+    TranscriptionServiceError,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _base_path() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _create_directories() -> None:
+    base = _base_path()
+    for folder in (base / "data" / "recordings", base / "data" / "results"):
+        folder.mkdir(parents=True, exist_ok=True)
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
+    _create_directories()
+    base = _base_path()
+
+    app = Flask(
+        __name__,
+        static_folder=str(base / "static"),
+        template_folder=str(base / "templates"),
+    )
+
+    transcriber = AssemblyAITranscriptionService(settings.assemblyai_api_key)
+    llm = OpenAILlmService(settings.openai_api_key, settings.openai_model)
+    email_sender = EmailSender(settings.email)
+
+    upload_dir = base / "data" / "recordings"
+    result_dir = base / "data" / "results"
+
+    @app.route("/")
+    def index() -> str:
+        return render_template(
+            "index.html",
+            email_enabled=settings.email.enabled,
+            default_recipient=settings.email.default_recipient or "",
+        )
+
+    @app.post("/upload")
+    def upload_audio():  # type: ignore[override]
+        if "audio" not in request.files:
+            return jsonify({"error": "No audio file supplied."}), 400
+
+        audio_file = request.files["audio"]
+        if not audio_file.filename:
+            return jsonify({"error": "Uploaded file has no filename."}), 400
+
+        extension = Path(audio_file.filename).suffix or ".webm"
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        output_name = f"meeting_{timestamp}{extension}"
+        destination = upload_dir / output_name
+        audio_file.save(destination)
+        LOGGER.info("Saved recording to %s", destination)
+
+        try:
+            transcription = transcriber.transcribe(destination)
+            transcript_text = format_transcript_text(transcription.segments)
+            llm_result = llm.summarize(transcript_text or transcription.text)
+        except TranscriptionServiceError as exc:
+            LOGGER.exception("Transcription failed")
+            return jsonify({"error": str(exc)}), 500
+        except LLMServiceError as exc:
+            LOGGER.exception("LLM summarisation failed")
+            return jsonify({"error": str(exc)}), 500
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.exception("Unexpected error during processing")
+            return jsonify({"error": "Unexpected error processing the recording."}), 500
+
+        return jsonify(
+            {
+                "fileName": output_name,
+                "segments": [
+                    {
+                        "speaker": segment.speaker,
+                        "text": segment.text,
+                        "start": segment.start,
+                        "end": segment.end,
+                    }
+                    for segment in transcription.segments
+                ],
+                "summary": llm_result.summary,
+                "actionItems": llm_result.action_items,
+                "transcriptText": transcript_text,
+            }
+        )
+
+    def _decode_segments(payload: Iterable[Dict]) -> List[TranscriptionSegment]:
+        segments: List[TranscriptionSegment] = []
+        for item in payload:
+            segments.append(
+                TranscriptionSegment(
+                    speaker=str(item.get("speaker", "Speaker")),
+                    text=str(item.get("text", "")),
+                    start=float(item.get("start", 0.0)),
+                    end=float(item.get("end", 0.0)),
+                )
+            )
+        return segments
+
+    @app.post("/save_result")
+    def save_result():  # type: ignore[override]
+        data = request.get_json(silent=True) or {}
+        summary = str(data.get("summary", ""))
+        action_items = data.get("actionItems") or []
+        if not isinstance(action_items, list):
+            action_items = []
+        segments_payload = data.get("segments") or []
+        overrides = data.get("speakerMap") or {}
+        file_name = data.get("fileName") or f"meeting_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.txt"
+
+        segments = _decode_segments(segments_payload)
+        document = build_result_document(summary, action_items, segments, overrides)
+        destination = result_dir / file_name
+        destination.write_text(document, encoding="utf-8")
+
+        email_status = None
+        if data.get("sendEmail"):
+            recipient = data.get("emailAddress") or None
+            try:
+                email_sender.send("Meeting Summary", document, recipient=recipient)
+                email_status = "sent"
+            except EmailNotConfiguredError as exc:
+                return jsonify({"error": str(exc)}), 400
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception("Email dispatch failed")
+                return jsonify({"error": "Failed to send email."}), 500
+
+        return jsonify({"savedTo": str(destination), "emailStatus": email_status})
+
+    return app
+
+
+app = create_app()
+
+__all__ = ["app", "create_app"]

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for the meeting recorder application."""

--- a/app/services/emailer.py
+++ b/app/services/emailer.py
@@ -1,0 +1,73 @@
+"""Email integration for exporting meeting summaries."""
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from typing import Optional, Protocol, runtime_checkable
+
+from ..config import EmailSettings
+
+
+class EmailNotConfiguredError(RuntimeError):
+    """Raised when email sending is requested but not configured."""
+
+
+@runtime_checkable
+class SMTPClient(Protocol):
+    """Protocol describing the subset of smtplib.SMTP used by EmailSender."""
+
+    def starttls(self) -> None:  # pragma: no cover - protocol definition
+        ...
+
+    def login(self, username: str, password: str) -> None:  # pragma: no cover
+        ...
+
+    def send_message(self, message: EmailMessage) -> None:  # pragma: no cover
+        ...
+
+    def quit(self) -> None:  # pragma: no cover
+        ...
+
+
+class EmailSender:
+    """Utility class responsible for dispatching emails."""
+
+    def __init__(self, settings: EmailSettings, smtp_factory=smtplib.SMTP) -> None:
+        self._settings = settings
+        self._smtp_factory = smtp_factory
+
+    def _require_enabled(self) -> None:
+        if not self._settings.enabled:
+            raise EmailNotConfiguredError("Email sending is disabled. Set EMAIL_ENABLED=true.")
+        if not self._settings.smtp_server:
+            raise EmailNotConfiguredError("SMTP_SERVER must be configured for email sending.")
+
+    def send(self, subject: str, body: str, recipient: Optional[str] = None) -> None:
+        """Send an email with the supplied subject and body."""
+
+        self._require_enabled()
+        recipient = recipient or self._settings.default_recipient
+        if not recipient:
+            raise EmailNotConfiguredError("Recipient email is not configured.")
+
+        sender = self._settings.default_sender or self._settings.smtp_username
+        if not sender:
+            raise EmailNotConfiguredError("Sender email is not configured.")
+
+        with self._smtp_factory(self._settings.smtp_server, self._settings.smtp_port) as client:
+            smtp_client: SMTPClient = client
+            if self._settings.use_tls:
+                smtp_client.starttls()
+            if self._settings.smtp_username and self._settings.smtp_password:
+                smtp_client.login(self._settings.smtp_username, self._settings.smtp_password)
+
+            message = EmailMessage()
+            message["Subject"] = subject
+            message["From"] = sender
+            message["To"] = recipient
+            message.set_content(body)
+
+            smtp_client.send_message(message)
+
+
+__all__ = ["EmailSender", "EmailNotConfiguredError"]

--- a/app/services/formatter.py
+++ b/app/services/formatter.py
@@ -1,0 +1,87 @@
+"""Helper utilities for shaping transcription and summary output."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterable, Mapping, Sequence
+
+from .transcription import TranscriptionSegment
+
+
+@dataclass(frozen=True)
+class RenderedSegment:
+    """Lightweight representation of a transcript line."""
+
+    timestamp: str
+    speaker: str
+    text: str
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format a float number of seconds into HH:MM:SS."""
+
+    return str(timedelta(seconds=int(seconds)))
+
+
+def apply_speaker_overrides(
+    segments: Iterable[TranscriptionSegment],
+    overrides: Mapping[str, str] | None = None,
+) -> list[RenderedSegment]:
+    """Apply speaker overrides to transcript segments and render them."""
+
+    rendered: list[RenderedSegment] = []
+    overrides = overrides or {}
+    for segment in segments:
+        speaker = overrides.get(segment.speaker, segment.speaker)
+        rendered.append(
+            RenderedSegment(
+                timestamp=format_timestamp(segment.start),
+                speaker=speaker,
+                text=segment.text,
+            )
+        )
+    return rendered
+
+
+def format_transcript_text(
+    segments: Sequence[TranscriptionSegment],
+    overrides: Mapping[str, str] | None = None,
+) -> str:
+    """Build a human readable transcript string."""
+
+    lines = [
+        f"[{rendered.timestamp}] {rendered.speaker}: {rendered.text}"
+        for rendered in apply_speaker_overrides(segments, overrides)
+    ]
+    return "\n".join(lines).strip()
+
+
+def build_result_document(
+    summary: str,
+    action_items: Sequence[str],
+    segments: Sequence[TranscriptionSegment],
+    overrides: Mapping[str, str] | None = None,
+) -> str:
+    """Generate a text document containing summary, actions and transcript."""
+
+    transcript_body = format_transcript_text(segments, overrides)
+
+    parts = ["Meeting Summary", "==============", summary.strip() or "(No summary provided)"]
+
+    parts.extend(["", "Action Items", "============"])
+    if action_items:
+        parts.extend([f"- {item}" for item in action_items])
+    else:
+        parts.append("(No action items recorded)")
+
+    parts.extend(["", "Transcript", "==========", transcript_body or "(No transcript available)"])
+    return "\n".join(parts).strip() + "\n"
+
+
+__all__ = [
+    "RenderedSegment",
+    "apply_speaker_overrides",
+    "build_result_document",
+    "format_timestamp",
+    "format_transcript_text",
+]

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,0 +1,84 @@
+"""LLM integration helpers."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import List, Optional
+
+from openai import OpenAI
+
+
+@dataclass
+class SummaryResult:
+    """Normalized output from the language model."""
+
+    summary: str
+    action_items: List[str]
+    raw_response: str
+
+
+class LLMServiceError(RuntimeError):
+    """Raised when the LLM service is not available or fails."""
+
+
+class OpenAILlmService:
+    """Simple wrapper around OpenAI's chat completion API."""
+
+    def __init__(self, api_key: Optional[str], model: str = "gpt-4o-mini") -> None:
+        self.api_key = api_key
+        self.model = model
+        self._client = OpenAI(api_key=api_key) if api_key else None
+
+    def summarize(self, transcript_text: str) -> SummaryResult:
+        """Request a structured summary and list of action items from OpenAI."""
+
+        if not transcript_text.strip():
+            raise LLMServiceError("Transcript is empty; cannot summarize an empty meeting.")
+        if not self._client:
+            raise LLMServiceError("OpenAI API key is not configured. Set OPENAI_API_KEY.")
+
+        system_message = (
+            "You are an assistant that summarises business meetings. "
+            "Return concise summaries and actionable bullet points."
+        )
+        user_prompt = (
+            "Summarise the following meeting transcript and list clear action items. "
+            "Respond with JSON using the keys 'summary' and 'action_items'. "
+            "The 'action_items' value must be an array of strings.\n\n" + transcript_text
+        )
+
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.2,
+        )
+        message = response.choices[0].message.content or ""
+
+        summary, action_items = self._parse_response(message)
+        return SummaryResult(summary=summary, action_items=action_items, raw_response=message)
+
+    @staticmethod
+    def _parse_response(message: str) -> tuple[str, List[str]]:
+        """Parse JSON response, falling back to plain text if parsing fails."""
+
+        try:
+            payload = json.loads(message)
+        except json.JSONDecodeError:
+            return message.strip(), []
+
+        summary = str(payload.get("summary", "")).strip()
+        raw_action_items = payload.get("action_items", [])
+        if isinstance(raw_action_items, list):
+            action_items = [str(item).strip() for item in raw_action_items if str(item).strip()]
+        elif isinstance(raw_action_items, str):
+            action_items = [line.strip() for line in raw_action_items.splitlines() if line.strip()]
+        else:
+            action_items = []
+
+        return summary, action_items
+
+
+__all__ = ["OpenAILlmService", "SummaryResult", "LLMServiceError"]

--- a/app/services/transcription.py
+++ b/app/services/transcription.py
@@ -1,0 +1,158 @@
+"""Utilities for transcribing recorded meetings."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+try:  # pragma: no cover - dependency may be missing during tests
+    import requests
+except ModuleNotFoundError:  # pragma: no cover
+    requests = None  # type: ignore[assignment]
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptionSegment:
+    """Represents a single speaker segment in a transcription."""
+
+    speaker: str
+    text: str
+    start: float
+    end: float
+
+
+@dataclass
+class TranscriptionResult:
+    """Aggregate result of a transcription request."""
+
+    text: str
+    segments: List[TranscriptionSegment]
+    duration_seconds: Optional[float] = None
+
+
+class TranscriptionServiceError(RuntimeError):
+    """Raised when the transcription service fails to process the audio."""
+
+
+class AssemblyAITranscriptionService:
+    """Wrapper around AssemblyAI's transcription API."""
+
+    _UPLOAD_ENDPOINT = "https://api.assemblyai.com/v2/upload"
+    _TRANSCRIPT_ENDPOINT = "https://api.assemblyai.com/v2/transcript"
+
+    def __init__(self, api_key: Optional[str]) -> None:
+        self.api_key = api_key
+
+    def _headers(self) -> dict[str, str]:
+        if not self.api_key:
+            raise TranscriptionServiceError(
+                "AssemblyAI API key is not configured. Set ASSEMBLYAI_API_KEY."
+            )
+        return {"authorization": self.api_key}
+
+    @staticmethod
+    def _read_file(path: Path, chunk_size: int = 5_242_880) -> Iterable[bytes]:
+        """Yield chunks from the given file path suitable for streaming uploads."""
+
+        with path.open("rb") as handle:
+            while True:
+                data = handle.read(chunk_size)
+                if not data:
+                    break
+                yield data
+
+    def _upload_audio(self, audio_path: Path) -> str:
+        if requests is None:
+            raise TranscriptionServiceError("The 'requests' package is required for transcription.")
+        headers = self._headers()
+        LOGGER.debug("Uploading %s to AssemblyAI", audio_path)
+        response = requests.post(
+            self._UPLOAD_ENDPOINT,
+            headers=headers,
+            data=self._read_file(audio_path),
+        )
+        response.raise_for_status()
+        upload_url = response.json()["upload_url"]
+        LOGGER.debug("Upload successful: %s", upload_url)
+        return upload_url
+
+    def _request_transcription(self, upload_url: str) -> str:
+        if requests is None:
+            raise TranscriptionServiceError("The 'requests' package is required for transcription.")
+        headers = self._headers()
+        LOGGER.debug("Requesting transcription for %s", upload_url)
+        response = requests.post(
+            self._TRANSCRIPT_ENDPOINT,
+            headers=headers,
+            json={
+                "audio_url": upload_url,
+                "speaker_labels": True,
+                "auto_highlights": False,
+            },
+        )
+        response.raise_for_status()
+        transcript_id = response.json()["id"]
+        LOGGER.debug("Transcript job created: %s", transcript_id)
+        return transcript_id
+
+    def _poll_transcription(self, transcript_id: str, interval: float = 3.0) -> dict:
+        if requests is None:
+            raise TranscriptionServiceError("The 'requests' package is required for transcription.")
+        headers = self._headers()
+        status_endpoint = f"{self._TRANSCRIPT_ENDPOINT}/{transcript_id}"
+        while True:
+            response = requests.get(status_endpoint, headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+            status = payload.get("status")
+            LOGGER.debug("Transcript %s status: %s", transcript_id, status)
+            if status == "completed":
+                return payload
+            if status == "error":
+                raise TranscriptionServiceError(payload.get("error", "Unknown error"))
+            time.sleep(interval)
+
+    def transcribe(self, audio_path: Path) -> TranscriptionResult:
+        """Transcribe the audio file, returning diarised segments."""
+
+        upload_url = self._upload_audio(audio_path)
+        transcript_id = self._request_transcription(upload_url)
+        payload = self._poll_transcription(transcript_id)
+
+        utterances = payload.get("utterances") or []
+        segments: List[TranscriptionSegment] = []
+        speaker_labels: dict[str, str] = {}
+
+        for utterance in utterances:
+            raw_label = utterance.get("speaker", "Unknown")
+            if raw_label not in speaker_labels:
+                speaker_labels[raw_label] = f"Speaker {len(speaker_labels) + 1}"
+            label = speaker_labels[raw_label]
+            segments.append(
+                TranscriptionSegment(
+                    speaker=label,
+                    text=utterance.get("text", "").strip(),
+                    start=float(utterance.get("start", 0)) / 1000.0,
+                    end=float(utterance.get("end", 0)) / 1000.0,
+                )
+            )
+
+        combined_text = " ".join(segment.text for segment in segments).strip()
+        duration = payload.get("audio_duration")
+        return TranscriptionResult(
+            text=combined_text,
+            segments=segments,
+            duration_seconds=float(duration) if duration is not None else None,
+        )
+
+
+__all__ = [
+    "AssemblyAITranscriptionService",
+    "TranscriptionResult",
+    "TranscriptionSegment",
+    "TranscriptionServiceError",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=2.3,<3.0
+requests>=2.31
+openai>=1.3.0
+pytest>=7.4

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,114 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  background: #f8f9fb;
+  color: #1a1a1a;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.controls button {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  background: #0b5ed7;
+  color: white;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+.controls button[disabled] {
+  background: #9aa0b1;
+  cursor: not-allowed;
+}
+
+.controls button:not([disabled]):hover {
+  background: #0949a5;
+}
+
+#status,
+#export-status {
+  font-style: italic;
+}
+
+.hidden {
+  display: none;
+}
+
+article {
+  background: white;
+  border-radius: 8px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+pre {
+  background: #0f172a;
+  color: #f1f5f9;
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 6px;
+  white-space: pre-wrap;
+}
+
+.export label {
+  display: block;
+  margin-bottom: 0.8rem;
+}
+
+.export label.inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.export button {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  background: #198754;
+  color: white;
+  cursor: pointer;
+}
+
+.hint {
+  color: #495057;
+  font-size: 0.9rem;
+}
+
+#speaker-labels {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+#speaker-labels label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+#speaker-labels input {
+  margin-top: 0.3rem;
+  padding: 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #ced4da;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,297 @@
+(function () {
+  const startBtn = document.getElementById('start-btn');
+  const pauseBtn = document.getElementById('pause-btn');
+  const resumeBtn = document.getElementById('resume-btn');
+  const stopBtn = document.getElementById('stop-btn');
+  const saveBtn = document.getElementById('save-btn');
+  const statusEl = document.getElementById('status');
+  const exportStatusEl = document.getElementById('export-status');
+  const resultsSection = document.getElementById('results');
+  const summaryEl = document.getElementById('summary');
+  const actionItemsEl = document.getElementById('action-items');
+  const transcriptEl = document.getElementById('transcript');
+  const speakerLabelsContainer = document.getElementById('speaker-labels');
+  const fileNameInput = document.getElementById('file-name');
+  const sendEmailCheckbox = document.getElementById('send-email');
+  const emailAddressWrapper = document.getElementById('email-address-wrapper');
+  const emailAddressInput = document.getElementById('email-address');
+
+  let mediaRecorder = null;
+  let recordedChunks = [];
+  const state = {
+    segments: [],
+    speakerMap: {},
+    summary: '',
+    actionItems: [],
+    fileName: '',
+  };
+
+  function setStatus(text) {
+    statusEl.textContent = text || '';
+  }
+
+  function setExportStatus(text) {
+    exportStatusEl.textContent = text || '';
+  }
+
+  function formatTimestamp(seconds) {
+    const total = Math.max(0, Math.floor(seconds || 0));
+    const hrs = String(Math.floor(total / 3600)).padStart(2, '0');
+    const mins = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+    const secs = String(total % 60).padStart(2, '0');
+    return `${hrs}:${mins}:${secs}`;
+  }
+
+  function updateButtonStates() {
+    const recorderState = mediaRecorder ? mediaRecorder.state : 'inactive';
+    startBtn.disabled = recorderState !== 'inactive';
+    pauseBtn.disabled = recorderState !== 'recording';
+    resumeBtn.disabled = recorderState !== 'paused';
+    stopBtn.disabled = recorderState === 'inactive';
+  }
+
+  function resetRecorder() {
+    if (mediaRecorder && mediaRecorder.stream) {
+      mediaRecorder.stream.getTracks().forEach((track) => track.stop());
+    }
+    mediaRecorder = null;
+    recordedChunks = [];
+    updateButtonStates();
+  }
+
+  function renderActionItems(items) {
+    actionItemsEl.innerHTML = '';
+    if (!items || items.length === 0) {
+      const emptyItem = document.createElement('li');
+      emptyItem.textContent = 'No action items identified.';
+      actionItemsEl.appendChild(emptyItem);
+      return;
+    }
+
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      actionItemsEl.appendChild(li);
+    });
+  }
+
+  function renderTranscript() {
+    const lines = state.segments.map((segment) => {
+      const speaker = state.speakerMap[segment.speaker] || segment.speaker;
+      return `[${formatTimestamp(segment.start)}] ${speaker}: ${segment.text}`;
+    });
+    transcriptEl.textContent = lines.join('\n');
+  }
+
+  function renderSpeakerInputs() {
+    speakerLabelsContainer.innerHTML = '';
+    const speakers = Array.from(new Set(state.segments.map((segment) => segment.speaker)));
+    speakers.forEach((speaker) => {
+      if (!state.speakerMap[speaker]) {
+        state.speakerMap[speaker] = speaker;
+      }
+      const wrapper = document.createElement('label');
+      wrapper.textContent = `Label for ${speaker}`;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = state.speakerMap[speaker];
+      input.dataset.speaker = speaker;
+      input.addEventListener('input', (event) => {
+        const value = event.target.value.trim();
+        state.speakerMap[speaker] = value || speaker;
+        renderTranscript();
+      });
+      wrapper.appendChild(input);
+      speakerLabelsContainer.appendChild(wrapper);
+    });
+  }
+
+  function showResults(data) {
+    state.summary = data.summary || 'No summary available.';
+    state.actionItems = data.actionItems || [];
+    state.segments = data.segments || [];
+    state.speakerMap = {};
+
+    summaryEl.textContent = state.summary;
+    renderActionItems(state.actionItems);
+    renderSpeakerInputs();
+    renderTranscript();
+
+    resultsSection.classList.remove('hidden');
+    saveBtn.disabled = false;
+  }
+
+  function handleError(error) {
+    console.error(error);
+    setStatus('An error occurred. Check console for details.');
+  }
+
+  async function uploadRecording(blob) {
+    setStatus('Uploading recording…');
+    const formData = new FormData();
+    formData.append('audio', blob, `recording_${Date.now()}.webm`);
+
+    try {
+      const response = await fetch('/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error || 'Failed to process recording.');
+      }
+      const payload = await response.json();
+      showResults(payload);
+      setStatus('Processing complete.');
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  async function saveResults() {
+    if (!state.segments.length) {
+      setExportStatus('No results to save yet.');
+      return;
+    }
+
+    const fileName = fileNameInput.value.trim() || undefined;
+    const sendEmail = !!sendEmailCheckbox.checked && !sendEmailCheckbox.disabled;
+    const emailAddress = emailAddressInput.value.trim() || undefined;
+
+    const payload = {
+      summary: state.summary,
+      actionItems: state.actionItems,
+      segments: state.segments,
+      speakerMap: state.speakerMap,
+      fileName,
+      sendEmail,
+      emailAddress,
+    };
+
+    setExportStatus('Saving…');
+    try {
+      const response = await fetch('/save_result', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save result.');
+      }
+      setExportStatus(`Saved to ${data.savedTo}${data.emailStatus ? ' and email sent.' : '.'}`);
+    } catch (error) {
+      setExportStatus(error.message);
+    }
+  }
+
+  async function startRecording() {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorder = new MediaRecorder(stream);
+      recordedChunks = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          recordedChunks.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstart = () => {
+        setStatus('Recording…');
+        updateButtonStates();
+      };
+
+      mediaRecorder.onpause = () => {
+        setStatus('Recording paused.');
+        updateButtonStates();
+      };
+
+      mediaRecorder.onresume = () => {
+        setStatus('Recording…');
+        updateButtonStates();
+      };
+
+      mediaRecorder.onstop = async () => {
+        setStatus('Processing recording…');
+        updateButtonStates();
+        const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+        resetRecorder();
+        await uploadRecording(blob);
+      };
+
+      mediaRecorder.start();
+      updateButtonStates();
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function pauseRecording() {
+    if (mediaRecorder && mediaRecorder.state === 'recording') {
+      mediaRecorder.pause();
+    }
+  }
+
+  function resumeRecording() {
+    if (mediaRecorder && mediaRecorder.state === 'paused') {
+      mediaRecorder.resume();
+    }
+  }
+
+  function stopRecording() {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+  }
+
+  startBtn.addEventListener('click', startRecording);
+  pauseBtn.addEventListener('click', pauseRecording);
+  resumeBtn.addEventListener('click', resumeRecording);
+  stopBtn.addEventListener('click', stopRecording);
+  saveBtn.addEventListener('click', saveResults);
+
+  saveBtn.disabled = true;
+
+  const emailEnabled = Boolean(window.APP_CONFIG && window.APP_CONFIG.emailEnabled);
+  if (!emailEnabled) {
+    sendEmailCheckbox.checked = false;
+    sendEmailCheckbox.disabled = true;
+    if (emailAddressWrapper) {
+      emailAddressWrapper.style.display = 'none';
+    }
+    if (emailAddressInput) {
+      emailAddressInput.disabled = true;
+    }
+  }
+
+  sendEmailCheckbox.addEventListener('change', () => {
+    if (!emailAddressWrapper) {
+      return;
+    }
+    if (sendEmailCheckbox.checked) {
+      emailAddressWrapper.style.display = 'flex';
+      if (emailAddressInput) {
+        emailAddressInput.disabled = false;
+      }
+    } else {
+      emailAddressWrapper.style.display = 'none';
+      if (emailAddressInput) {
+        emailAddressInput.disabled = true;
+      }
+    }
+  });
+
+  if (emailAddressWrapper && emailAddressInput && emailEnabled) {
+    emailAddressWrapper.style.display = sendEmailCheckbox.checked ? 'flex' : 'none';
+    emailAddressInput.disabled = !sendEmailCheckbox.checked;
+  }
+
+  updateButtonStates();
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Meeting Recorder</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Meeting Recorder</h1>
+        <p>
+          Record a meeting, transcribe it with speaker identification, and generate a
+          summary with action items.
+        </p>
+      </header>
+
+      <section class="controls">
+        <button id="start-btn">Start Recording</button>
+        <button id="pause-btn" disabled>Pause</button>
+        <button id="resume-btn" disabled>Resume</button>
+        <button id="stop-btn" disabled>Stop</button>
+        <span id="status" role="status"></span>
+      </section>
+
+      <section id="results" class="hidden">
+        <h2>Results</h2>
+
+        <article>
+          <h3>Summary</h3>
+          <p id="summary"></p>
+        </article>
+
+        <article>
+          <h3>Action Items</h3>
+          <ul id="action-items"></ul>
+        </article>
+
+        <article>
+          <h3>Speaker Labels</h3>
+          <p class="hint">
+            Update the speaker names below to make the transcript easier to read.
+          </p>
+          <div id="speaker-labels"></div>
+        </article>
+
+        <article>
+          <h3>Transcript</h3>
+          <pre id="transcript"></pre>
+        </article>
+
+        <section class="export">
+          <h3>Export</h3>
+          <label>
+            File name
+            <input id="file-name" type="text" placeholder="meeting_notes.txt" />
+          </label>
+          <label class="inline">
+            <input id="send-email" type="checkbox" {% if email_enabled %}checked{% endif %} />
+            Email the result
+          </label>
+          <label id="email-address-wrapper" class="inline">
+            Email address
+            <input
+              id="email-address"
+              type="email"
+              placeholder="{{ default_recipient }}"
+              value="{{ default_recipient }}"
+            />
+          </label>
+          <button id="save-btn">Save Results</button>
+          <span id="export-status" role="status"></span>
+        </section>
+      </section>
+    </main>
+
+    <script>
+      window.APP_CONFIG = {
+        emailEnabled: {{ 'true' if email_enabled else 'false' }},
+      };
+    </script>
+    <script src="{{ url_for('static', filename='js/app.js') }}" defer></script>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for ensuring the application package is importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -1,0 +1,82 @@
+"""Unit tests for the email sender."""
+from __future__ import annotations
+
+from email.message import EmailMessage
+
+import pytest
+
+from app.config import EmailSettings
+from app.services.emailer import EmailNotConfiguredError, EmailSender
+
+
+class DummySMTP:
+    """Simple SMTP stub that records interactions."""
+
+    def __init__(self, server: str, port: int) -> None:
+        self.server = server
+        self.port = port
+        self.started_tls = False
+        self.login_credentials: tuple[str, str] | None = None
+        self.messages: list[EmailMessage] = []
+
+    def __enter__(self) -> "DummySMTP":  # pragma: no cover - simple context manager
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover
+        return None
+
+    def starttls(self) -> None:
+        self.started_tls = True
+
+    def login(self, username: str, password: str) -> None:
+        self.login_credentials = (username, password)
+
+    def send_message(self, message: EmailMessage) -> None:
+        self.messages.append(message)
+
+    def quit(self) -> None:  # pragma: no cover - smtplib compat
+        return None
+
+
+def test_email_sender_dispatches_message() -> None:
+    settings = EmailSettings(
+        enabled=True,
+        smtp_server="smtp.test",
+        smtp_port=587,
+        smtp_username="user@test",
+        smtp_password="secret",
+        use_tls=True,
+        default_sender="noreply@test",
+        default_recipient="recipient@test",
+    )
+
+    instances: list[DummySMTP] = []
+
+    def factory(server: str, port: int) -> DummySMTP:
+        instance = DummySMTP(server, port)
+        instances.append(instance)
+        return instance
+
+    sender = EmailSender(settings, smtp_factory=factory)
+    sender.send("Subject", "Body text")
+
+    assert instances, "Expected factory to be called"
+    smtp = instances[0]
+    assert smtp.server == "smtp.test"
+    assert smtp.started_tls is True
+    assert smtp.login_credentials == ("user@test", "secret")
+    assert smtp.messages and smtp.messages[0]["To"] == "recipient@test"
+
+
+def test_email_sender_requires_configuration() -> None:
+    settings = EmailSettings(
+        enabled=False,
+        smtp_server=None,
+        default_sender=None,
+        default_recipient=None,
+    )
+
+    sender = EmailSender(settings, smtp_factory=lambda *_args, **_kwargs: DummySMTP("", 0))
+
+    with pytest.raises(EmailNotConfiguredError):
+        sender.send("Subject", "Body")

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,44 @@
+"""Unit tests for formatter helpers."""
+from __future__ import annotations
+
+from app.services.formatter import (
+    apply_speaker_overrides,
+    build_result_document,
+    format_transcript_text,
+)
+from app.services.transcription import TranscriptionSegment
+
+
+def make_segment(speaker: str, text: str, start: float) -> TranscriptionSegment:
+    return TranscriptionSegment(speaker=speaker, text=text, start=start, end=start + 1)
+
+
+def test_format_transcript_text_with_overrides() -> None:
+    segments = [
+        make_segment("Speaker 1", "Hello there", 0),
+        make_segment("Speaker 2", "General Kenobi", 5),
+    ]
+
+    text = format_transcript_text(segments, overrides={"Speaker 2": "Obi-Wan"})
+
+    assert "Speaker 1" in text
+    assert "Obi-Wan" in text
+    assert "General Kenobi" in text
+
+
+def test_apply_speaker_overrides_preserves_order() -> None:
+    segments = [make_segment("Speaker 1", "Test", 0), make_segment("Speaker 1", "Again", 1)]
+    rendered = apply_speaker_overrides(segments, overrides={"Speaker 1": "Alice"})
+    assert [segment.text for segment in rendered] == ["Test", "Again"]
+    assert all(segment.speaker == "Alice" for segment in rendered)
+
+
+def test_build_result_document_contains_all_sections() -> None:
+    segments = [make_segment("Speaker 1", "First", 0)]
+    document = build_result_document("Summary", ["Item"], segments)
+
+    assert "Meeting Summary" in document
+    assert "Action Items" in document
+    assert "Transcript" in document
+    assert "Item" in document
+    assert "First" in document


### PR DESCRIPTION
## Summary
- implement a Flask application that records meetings, transcribes audio with AssemblyAI, summarises the text with OpenAI, and exports results
- build a browser UI to control recording, relabel speakers, and save or email meeting notes
- add configuration, formatting, and email utilities with accompanying unit tests and ignore transient build artefacts

## Testing
- pytest
- python -m compileall app tests

------
https://chatgpt.com/codex/tasks/task_e_68c94864fec48321bd4e012bcc30a4c1