### PR TITLE
Add Gradio meeting recorder app with transcription and summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
 # MeetingRecorder
-AI based meeting notes assistant
 
 Python based application for recording, transcribing and summarizing meetings.
+
+## Features
+
+- Record meeting audio directly in the browser with options to start, pause and stop the capture.
+- Transcribe meetings using [AssemblyAI](https://www.assemblyai.com/) with automatic speaker diarisation.
+- Label speakers manually to make the transcript more readable.
+- Summarise the meeting and extract action items using either OpenAI or a local Ollama model.
+- Persist the generated notes to Markdown files and optionally email them to a configured recipient.
+
+## Running the app
+
+1. Install the Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Export the required environment variables:
+
+   - `ASSEMBLYAI_API_KEY` – required for transcription.
+   - `OPENAI_API_KEY` – optional. Provides access to OpenAI's chat models.
+   - `OPENAI_MODEL` – optional. Defaults to `gpt-3.5-turbo`.
+   - `OLLAMA_MODEL` – optional. Use instead of OpenAI to target a local Ollama instance.
+   - `MEETING_OUTPUT_DIR` – optional. Directory for generated Markdown files.
+   - `EMAIL_SMTP_SERVER`, `EMAIL_SMTP_PORT`, `EMAIL_USERNAME`, `EMAIL_PASSWORD`,
+     `EMAIL_FROM_ADDRESS`, `EMAIL_TO_ADDRESS`, `EMAIL_USE_TLS` – optional settings for the
+     email integration.
+
+3. Launch the Gradio interface:
+
+   ```bash
+   python -m meeting_recorder.app
+   ```
+
+4. Record the meeting, stop the recording and click **Transcribe & Summarise** to process
+   the audio. Download the generated Markdown file or tick *Email the summary* to send
+   it to the configured address.
+
+## Tests
+
+Unit tests can be executed with `pytest`:
+
+```bash
+pytest
+```

--- a/meeting_recorder/__init__.py
+++ b/meeting_recorder/__init__.py
@@ -1,0 +1,19 @@
+"""Top level package for the Meeting Recorder application."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    import gradio as gr
+
+
+def build_app() -> "gr.Blocks":
+    """Return the configured Gradio application."""
+
+    from .app import build_app as _build_app
+
+    return _build_app()
+
+
+__all__ = ["build_app"]

--- a/meeting_recorder/app.py
+++ b/meeting_recorder/app.py
@@ -1,0 +1,165 @@
+"""Gradio user interface for the Meeting Recorder application."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import gradio as gr
+
+from .config import AppConfig
+from .emailer import send_email_with_summary
+from .storage import save_meeting_result
+from .summarizer import LLMSummarizer, MeetingSummary
+from .transcription import TranscriptionResult, parse_speaker_labels, transcribe_audio
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _format_summary_markdown(summary: MeetingSummary) -> str:
+    lines = ["## Summary"]
+    lines.append(summary.summary or "No summary generated.")
+    return "\n\n".join(lines)
+
+
+def _format_action_markdown(action_items: List[str]) -> str:
+    lines = ["## Action Items"]
+    if action_items:
+        lines.extend(f"- {item}" for item in action_items)
+    else:
+        lines.append("- No action items identified.")
+    return "\n".join(lines)
+
+
+def _process_meeting(
+    audio_path: str | None,
+    speaker_label_text: str,
+    send_email: bool,
+    config: AppConfig,
+    summarizer: LLMSummarizer,
+) -> Tuple[str, str, str, str, str | None]:
+    """Handle the end-to-end meeting processing workflow."""
+
+    if not audio_path:
+        message = "⚠️ No audio captured. Please record the meeting before processing."
+        return "", "", "", message, None
+
+    try:
+        labels: Dict[str, str] = parse_speaker_labels(speaker_label_text)
+        transcription: TranscriptionResult = transcribe_audio(audio_path, config, labels)
+        summary: MeetingSummary = summarizer.summarise(transcription.text)
+        output_path: Path = save_meeting_result(transcription, summary, config.output_dir)
+    except Exception as exc:  # pragma: no cover - exercised through UI only
+        LOGGER.exception("Failed to process meeting")
+        return "", "", "", f"❌ Error: {exc}", None
+
+    email_message = ""
+    if send_email:
+        try:
+            body_lines = [summary.summary or "No summary generated.", "", "Action items:"]
+            body_lines.extend(summary.action_items or ["No action items identified."])
+            email_body = "\n".join(body_lines)
+            send_email_with_summary(
+                config.email,
+                subject="Automated meeting notes",
+                body=email_body,
+                attachment=output_path,
+            )
+            email_message = " Email sent to configured recipient."
+        except Exception as exc:  # pragma: no cover - network interaction
+            LOGGER.exception("Failed to send email")
+            email_message = f" Email delivery failed: {exc}."
+
+    transcription_markdown = transcription.format_markdown()
+    summary_markdown = _format_summary_markdown(summary)
+    action_markdown = _format_action_markdown(summary.action_items)
+    status_message = f"✅ Meeting processed. Notes saved to {output_path}.{email_message}"
+
+    return (
+        transcription_markdown,
+        summary_markdown,
+        action_markdown,
+        status_message,
+        str(output_path),
+    )
+
+
+def build_app() -> gr.Blocks:
+    """Create the Gradio Blocks application."""
+
+    logging.basicConfig(level=logging.INFO)
+    config = AppConfig.from_env()
+    summarizer = LLMSummarizer(config)
+
+    with gr.Blocks(title="Meeting Recorder") as demo:
+        gr.Markdown(
+            """
+            # Meeting Recorder
+            Record meetings, transcribe them with speaker diarisation and extract action items.
+            """
+        )
+
+        recording_state = gr.State(False)
+        status_output = gr.Markdown("Ready to record.")
+
+        with gr.Row():
+            audio_input = gr.Audio(
+                label="Meeting audio",
+                sources=["microphone", "upload"],
+                type="filepath",
+            )
+
+        with gr.Row():
+            start_button = gr.Button("Start Recording", variant="primary")
+            pause_button = gr.Button("Pause Recording")
+            stop_button = gr.Button("Stop Recording")
+
+        def start_recording(_: bool) -> Tuple[bool, str]:
+            return True, "Recording started. Use the audio widget to speak."  # pragma: no cover
+
+        def pause_recording(is_recording: bool) -> Tuple[bool, str]:
+            if is_recording:
+                return False, "Recording paused. Resume by pressing start."
+            return False, "Recording is not active."  # pragma: no cover
+
+        def stop_recording(_: bool) -> Tuple[bool, str]:
+            return False, "Recording stopped. You can now process the meeting."
+
+        start_button.click(start_recording, inputs=recording_state, outputs=[recording_state, status_output])
+        pause_button.click(pause_recording, inputs=recording_state, outputs=[recording_state, status_output])
+        stop_button.click(stop_recording, inputs=recording_state, outputs=[recording_state, status_output])
+
+        speaker_label_input = gr.Textbox(
+            label="Speaker labels (optional)",
+            placeholder="Speaker A=Alice\nSpeaker B=Bob",
+            lines=2,
+        )
+        send_email_checkbox = gr.Checkbox(label="Email the summary", value=False)
+
+        process_button = gr.Button("Transcribe & Summarise", variant="primary")
+
+        transcription_output = gr.Markdown(label="Transcript")
+        summary_output = gr.Markdown(label="Summary")
+        action_output = gr.Markdown(label="Action Items")
+        file_output = gr.File(label="Saved meeting notes")
+
+        process_button.click(
+            fn=lambda audio, labels, email: _process_meeting(
+                audio, labels, email, config, summarizer
+            ),
+            inputs=[audio_input, speaker_label_input, send_email_checkbox],
+            outputs=[
+                transcription_output,
+                summary_output,
+                action_output,
+                status_output,
+                file_output,
+            ],
+        )
+
+    return demo
+
+
+if __name__ == "__main__":
+    build_app().launch()

--- a/meeting_recorder/config.py
+++ b/meeting_recorder/config.py
@@ -1,0 +1,73 @@
+"""Configuration helpers for the Meeting Recorder app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(slots=True)
+class EmailConfig:
+    """Configuration required to send meeting summaries via email."""
+
+    smtp_server: Optional[str] = None
+    smtp_port: Optional[int] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    from_address: Optional[str] = None
+    to_address: Optional[str] = None
+    use_tls: bool = True
+
+    def is_configured(self) -> bool:
+        """Return ``True`` when all required fields are configured."""
+
+        required_fields = [
+            self.smtp_server,
+            self.smtp_port,
+            self.username,
+            self.password,
+            self.from_address,
+            self.to_address,
+        ]
+        return all(field not in (None, "") for field in required_fields)
+
+
+@dataclass(slots=True)
+class AppConfig:
+    """Application configuration read from environment variables."""
+
+    assemblyai_api_key: Optional[str] = None
+    openai_api_key: Optional[str] = None
+    openai_model: str = "gpt-3.5-turbo"
+    ollama_model: Optional[str] = None
+    output_dir: Path = Path("meeting_outputs")
+    email: EmailConfig = field(default_factory=EmailConfig)
+
+    @classmethod
+    def from_env(cls) -> "AppConfig":
+        """Create an :class:`AppConfig` using environment variables."""
+
+        output_dir = Path(os.getenv("MEETING_OUTPUT_DIR", "meeting_outputs"))
+        email_config = EmailConfig(
+            smtp_server=os.getenv("EMAIL_SMTP_SERVER"),
+            smtp_port=int(os.getenv("EMAIL_SMTP_PORT", "0")) or None,
+            username=os.getenv("EMAIL_USERNAME"),
+            password=os.getenv("EMAIL_PASSWORD"),
+            from_address=os.getenv("EMAIL_FROM_ADDRESS"),
+            to_address=os.getenv("EMAIL_TO_ADDRESS"),
+            use_tls=os.getenv("EMAIL_USE_TLS", "true").lower() != "false",
+        )
+
+        return cls(
+            assemblyai_api_key=os.getenv("ASSEMBLYAI_API_KEY"),
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            openai_model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+            ollama_model=os.getenv("OLLAMA_MODEL"),
+            output_dir=output_dir,
+            email=email_config,
+        )
+
+
+__all__ = ["EmailConfig", "AppConfig"]

--- a/meeting_recorder/emailer.py
+++ b/meeting_recorder/emailer.py
@@ -1,0 +1,44 @@
+"""Email helper for delivering meeting summaries."""
+
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from pathlib import Path
+
+from .config import EmailConfig
+
+
+def send_email_with_summary(
+    config: EmailConfig,
+    subject: str,
+    body: str,
+    attachment: Path | None = None,
+) -> None:
+    """Send an email containing the meeting summary."""
+
+    if not config.is_configured():
+        raise RuntimeError("Email configuration is incomplete; cannot send message.")
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = config.from_address
+    message["To"] = config.to_address
+    message.set_content(body)
+
+    if attachment is not None and attachment.exists():
+        message.add_attachment(
+            attachment.read_bytes(),
+            maintype="text",
+            subtype="markdown",
+            filename=attachment.name,
+        )
+
+    with smtplib.SMTP(config.smtp_server, config.smtp_port) as smtp:
+        if config.use_tls:
+            smtp.starttls()
+        smtp.login(config.username, config.password)
+        smtp.send_message(message)
+
+
+__all__ = ["send_email_with_summary"]

--- a/meeting_recorder/storage.py
+++ b/meeting_recorder/storage.py
@@ -1,0 +1,50 @@
+"""Persisting meeting outputs to disk."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from .summarizer import MeetingSummary
+from .transcription import TranscriptionResult
+
+
+def build_default_filename(prefix: str = "meeting") -> str:
+    """Return a timestamped file name."""
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return f"{prefix}-{timestamp}.md"
+
+
+def render_meeting_markdown(
+    transcription: TranscriptionResult, summary: MeetingSummary
+) -> str:
+    """Combine all meeting data into a single Markdown string."""
+
+    parts = ["# Meeting Notes", ""]
+    parts.append(summary.format_markdown())
+    parts.append("")
+    parts.append(transcription.format_markdown())
+    return "\n".join(parts)
+
+
+def save_meeting_result(
+    transcription: TranscriptionResult,
+    summary: MeetingSummary,
+    output_dir: Path,
+    filename: str | None = None,
+) -> Path:
+    """Persist the meeting transcript and summary in *output_dir*."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    file_name = filename or build_default_filename()
+    file_path = output_dir / file_name
+    markdown = render_meeting_markdown(transcription, summary)
+    file_path.write_text(markdown, encoding="utf-8")
+    return file_path
+
+
+__all__ = [
+    "build_default_filename",
+    "render_meeting_markdown",
+    "save_meeting_result",
+]

--- a/meeting_recorder/summarizer.py
+++ b/meeting_recorder/summarizer.py
@@ -1,0 +1,152 @@
+"""Summarisation utilities for meeting transcripts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency when running tests
+    import requests
+except Exception as exc:  # pragma: no cover - handled during runtime
+    requests = None  # type: ignore
+    _REQUESTS_IMPORT_ERROR = exc
+else:  # pragma: no cover - executed when dependency installed
+    _REQUESTS_IMPORT_ERROR = None
+
+try:  # pragma: no cover - optional dependency during testing
+    from openai import OpenAI
+except Exception:  # pragma: no cover - fallback when OpenAI SDK is absent
+    OpenAI = None  # type: ignore
+
+from .config import AppConfig
+
+
+@dataclass(slots=True)
+class MeetingSummary:
+    """Structured summary extracted from a meeting transcript."""
+
+    summary: str
+    action_items: List[str]
+
+    def format_markdown(self) -> str:
+        """Represent the summary and action items in Markdown."""
+
+        lines = ["## Summary", self.summary or "No summary generated."]
+        lines.append("\n## Action Items")
+        if self.action_items:
+            for item in self.action_items:
+                lines.append(f"- {item}")
+        else:
+            lines.append("- No action items identified.")
+        return "\n".join(lines)
+
+
+def build_summary_prompt(transcript: str) -> str:
+    """Return the prompt instructing the LLM how to summarise the transcript."""
+
+    return (
+        "You are a helpful meeting assistant. "
+        "Summarise the meeting transcript and extract clear action items. "
+        "Respond in JSON with keys 'summary' (string) and 'action_items' (list of strings)."
+        "\n\nTranscript:\n"
+        f"{transcript.strip()}"
+    )
+
+
+def parse_summary_response(model_response: str) -> MeetingSummary:
+    """Parse the JSON response returned by the LLM."""
+
+    try:
+        payload: Dict[str, object] = json.loads(model_response)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive parsing
+        raise ValueError("Model response is not valid JSON") from exc
+
+    summary = str(payload.get("summary", "")).strip()
+    raw_items = payload.get("action_items", [])
+    action_items: List[str] = []
+    if isinstance(raw_items, list):
+        action_items = [str(item).strip() for item in raw_items if str(item).strip()]
+    elif isinstance(raw_items, str) and raw_items.strip():
+        # Models occasionally return a single string containing bullet points.
+        action_items = [segment.strip(" -") for segment in raw_items.splitlines() if segment.strip()]
+
+    return MeetingSummary(summary=summary, action_items=action_items)
+
+
+class LLMSummarizer:
+    """Summarise transcripts using either OpenAI or a local Ollama model."""
+
+    def __init__(
+        self,
+        config: AppConfig,
+        openai_client: Optional[OpenAI] = None,
+        http_session: Optional[Any] = None,
+    ) -> None:
+        self.config = config
+        self._openai_client = openai_client
+        if http_session is not None:
+            self._http_session = http_session
+        elif requests is not None:
+            self._http_session = requests.Session()
+        else:  # pragma: no cover - triggered only when requests is absent
+            self._http_session = None
+
+    def summarise(self, transcript: str) -> MeetingSummary:
+        """Summarise a transcript and extract action items."""
+
+        if not transcript.strip():
+            raise ValueError("Transcript is empty; cannot summarise")
+
+        if self.config.openai_api_key:
+            return self._summarise_with_openai(transcript)
+        if self.config.ollama_model:
+            return self._summarise_with_ollama(transcript)
+        raise RuntimeError(
+            "No LLM configured. Set OPENAI_API_KEY or OLLAMA_MODEL in the environment."
+        )
+
+    # ------------------------------------------------------------------
+    # Provider specific implementations
+    # ------------------------------------------------------------------
+    def _summarise_with_openai(self, transcript: str) -> MeetingSummary:
+        if OpenAI is None:
+            raise RuntimeError("openai package not available. Install the official SDK.")
+
+        client = self._openai_client or OpenAI(api_key=self.config.openai_api_key)
+        prompt = build_summary_prompt(transcript)
+        response = client.chat.completions.create(  # type: ignore[attr-defined]
+            model=self.config.openai_model,
+            messages=[
+                {"role": "system", "content": "You are a professional meeting assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.2,
+        )
+        message = response.choices[0].message.content  # type: ignore[index]
+        if not message:
+            raise RuntimeError("OpenAI response did not include any content")
+        return parse_summary_response(message)
+
+    def _summarise_with_ollama(self, transcript: str) -> MeetingSummary:
+        if self._http_session is None:  # pragma: no cover - depends on optional dependency
+            raise RuntimeError("requests package is not installed") from _REQUESTS_IMPORT_ERROR
+        prompt = build_summary_prompt(transcript)
+        payload = {"model": self.config.ollama_model, "prompt": prompt, "stream": False}
+        response = self._http_session.post(
+            "http://localhost:11434/api/generate", timeout=300, json=payload
+        )
+        response.raise_for_status()
+        body = response.json()
+        message = body.get("response", "")
+        if not isinstance(message, str) or not message.strip():
+            raise RuntimeError("Ollama did not return any content")
+        return parse_summary_response(message)
+
+
+__all__ = [
+    "LLMSummarizer",
+    "MeetingSummary",
+    "build_summary_prompt",
+    "parse_summary_response",
+]

--- a/meeting_recorder/transcription.py
+++ b/meeting_recorder/transcription.py
@@ -1,0 +1,139 @@
+"""Utilities to transcribe audio using AssemblyAI with speaker diarisation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency when running tests
+    import assemblyai as aai
+except Exception as exc:  # pragma: no cover - import error handled at runtime
+    aai = None  # type: ignore
+    _ASSEMBLYAI_IMPORT_ERROR = exc
+else:  # pragma: no cover - executed in production environments
+    _ASSEMBLYAI_IMPORT_ERROR = None
+
+from .config import AppConfig
+
+
+@dataclass(slots=True)
+class Utterance:
+    """A single utterance in the meeting transcript."""
+
+    speaker: str
+    text: str
+    start: float
+    end: float
+
+
+@dataclass(slots=True)
+class TranscriptionResult:
+    """Container with both the full transcript and diarised utterances."""
+
+    text: str
+    utterances: List[Utterance]
+
+    def format_markdown(self) -> str:
+        """Return a Markdown representation of the transcript."""
+
+        lines: List[str] = ["## Transcript"]
+        for utterance in self.utterances:
+            start = format_timestamp(utterance.start)
+            lines.append(f"**{utterance.speaker} [{start}]**: {utterance.text}")
+        if not self.utterances:
+            lines.append(self.text)
+        return "\n\n".join(lines)
+
+
+def format_timestamp(milliseconds: float) -> str:
+    """Convert a timestamp in milliseconds to ``HH:MM:SS`` format."""
+
+    total_seconds = int(milliseconds / 1000)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def parse_speaker_labels(raw_value: Optional[str]) -> Dict[str, str]:
+    """Parse user supplied speaker labels into a mapping."""
+
+    mapping: Dict[str, str] = {}
+    if not raw_value:
+        return mapping
+
+    entries = re.split(r"[\n,;]+", raw_value)
+    for entry in entries:
+        if not entry.strip():
+            continue
+        if "=" in entry:
+            key, value = entry.split("=", 1)
+        elif ":" in entry:
+            key, value = entry.split(":", 1)
+        else:
+            continue
+        mapping[key.strip().lower()] = value.strip()
+    return mapping
+
+
+def apply_speaker_labels(speaker: str | None, mapping: Dict[str, str]) -> str:
+    """Return the human friendly speaker label if available."""
+
+    normalized_key = (speaker or "").strip().lower()
+    if normalized_key in mapping:
+        return mapping[normalized_key]
+    # AssemblyAI uses numeric or alphabetic identifiers. Present a nicer default.
+    return f"Speaker {speaker}" if speaker else "Speaker"
+
+
+def transcribe_audio(
+    audio_path: Path | str,
+    config: AppConfig,
+    speaker_labels: Optional[Dict[str, str]] = None,
+) -> TranscriptionResult:
+    """Transcribe *audio_path* using AssemblyAI and diarisation."""
+
+    if not config.assemblyai_api_key:
+        raise RuntimeError(
+            "AssemblyAI API key missing. Set the ASSEMBLYAI_API_KEY environment variable."
+        )
+
+    if aai is None:  # pragma: no cover - depends on optional dependency
+        raise RuntimeError("assemblyai package is not installed") from _ASSEMBLYAI_IMPORT_ERROR
+
+    path = Path(audio_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    aai.settings.api_key = config.assemblyai_api_key
+    transcription_config = aai.TranscriptionConfig(speaker_labels=True)
+    transcriber = aai.Transcriber()
+    transcript = transcriber.transcribe(str(path), config=transcription_config)
+
+    if transcript.status != "completed":
+        error_detail = getattr(transcript, "error", "Unknown error")
+        raise RuntimeError(f"Transcription failed: {error_detail}")
+
+    labels = speaker_labels or {}
+    utterances = [
+        Utterance(
+            speaker=apply_speaker_labels(utterance.speaker, labels),
+            text=utterance.text,
+            start=utterance.start,
+            end=utterance.end,
+        )
+        for utterance in transcript.utterances or []
+    ]
+
+    return TranscriptionResult(text=transcript.text or "", utterances=utterances)
+
+
+__all__ = [
+    "Utterance",
+    "TranscriptionResult",
+    "transcribe_audio",
+    "parse_speaker_labels",
+    "apply_speaker_labels",
+    "format_timestamp",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+gradio>=4.0.0
+assemblyai>=0.33.0
+openai>=1.3.0
+requests>=2.31.0
+pytest>=7.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test configuration for the Meeting Recorder package."""
+
+import sys
+from pathlib import Path
+
+# Ensure the package root is importable when tests are executed from the tests directory.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,40 @@
+"""Tests for persisting meeting notes to disk."""
+
+from pathlib import Path
+
+from meeting_recorder.storage import build_default_filename, render_meeting_markdown, save_meeting_result
+from meeting_recorder.summarizer import MeetingSummary
+from meeting_recorder.transcription import TranscriptionResult, Utterance
+
+
+def test_build_default_filename_generates_markdown_name() -> None:
+    filename = build_default_filename("demo")
+    assert filename.startswith("demo-")
+    assert filename.endswith(".md")
+
+
+def _sample_transcription() -> TranscriptionResult:
+    return TranscriptionResult(
+        text="Alice greeted Bob.",
+        utterances=[Utterance(speaker="Alice", text="Hello Bob", start=0, end=1000)],
+    )
+
+
+def _sample_summary() -> MeetingSummary:
+    return MeetingSummary(summary="Discussed project kickoff", action_items=["Email the plan"])
+
+
+def test_render_meeting_markdown_contains_sections() -> None:
+    markdown = render_meeting_markdown(_sample_transcription(), _sample_summary())
+    assert "# Meeting Notes" in markdown
+    assert "## Summary" in markdown
+    assert "## Transcript" in markdown
+    assert "Alice" in markdown
+
+
+def test_save_meeting_result_creates_file(tmp_path: Path) -> None:
+    path = save_meeting_result(_sample_transcription(), _sample_summary(), tmp_path)
+    assert path.exists()
+    contents = path.read_text(encoding="utf-8")
+    assert "Meeting Notes" in contents
+    assert "Email the plan" in contents

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,31 @@
+"""Tests for the LLM summariser helpers."""
+
+import json
+
+import pytest
+
+from meeting_recorder.summarizer import MeetingSummary, build_summary_prompt, parse_summary_response
+
+
+def test_build_summary_prompt_includes_transcript() -> None:
+    transcript = "Alice: Hello"
+    prompt = build_summary_prompt(transcript)
+    assert "Alice: Hello" in prompt
+    assert "Respond in JSON" in prompt
+
+
+def test_parse_summary_response_from_valid_json() -> None:
+    payload = {"summary": "Important decisions", "action_items": ["Follow up"]}
+    summary = parse_summary_response(json.dumps(payload))
+    assert summary == MeetingSummary(summary="Important decisions", action_items=["Follow up"])
+
+
+def test_parse_summary_response_with_string_action_items() -> None:
+    payload = {"summary": "Discussed roadmap", "action_items": "- Task one\n- Task two"}
+    summary = parse_summary_response(json.dumps(payload))
+    assert summary.action_items == ["Task one", "Task two"]
+
+
+def test_parse_summary_response_invalid_json() -> None:
+    with pytest.raises(ValueError):
+        parse_summary_response("not-json")

--- a/tests/test_transcription_utils.py
+++ b/tests/test_transcription_utils.py
@@ -1,0 +1,25 @@
+"""Unit tests for transcription helper utilities."""
+
+from meeting_recorder.transcription import (
+    apply_speaker_labels,
+    format_timestamp,
+    parse_speaker_labels,
+)
+
+
+def test_parse_speaker_labels_supports_multiple_separators() -> None:
+    labels = parse_speaker_labels("Speaker A=Alice,Speaker B=Bob;C:Charlie")
+    assert labels == {"speaker a": "Alice", "speaker b": "Bob", "c": "Charlie"}
+
+
+def test_apply_speaker_labels_defaults_when_unknown() -> None:
+    mapping = {"speaker a": "Alice"}
+    assert apply_speaker_labels("Speaker A", mapping) == "Alice"
+    assert apply_speaker_labels("B", mapping) == "Speaker B"
+    assert apply_speaker_labels(None, mapping) == "Speaker"
+
+
+def test_format_timestamp() -> None:
+    assert format_timestamp(0) == "00:00:00"
+    assert format_timestamp(65_000) == "00:01:05"
+    assert format_timestamp(3_600_000) == "01:00:00"


### PR DESCRIPTION
## Summary
- add a Gradio UI that records meetings, captures speaker labels, and triggers transcription plus summarisation
- integrate AssemblyAI-based transcription, OpenAI/Ollama summarisation, Markdown export, and optional email delivery utilities
- document environment requirements and supply unit tests for formatting, parsing, and storage helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95720046c8321a39756ee9223be51