### PR TITLE
Switch to OpenAI client and improve audio handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gradio>=4.27.0
 requests>=2.31.0
 pytest>=8.0.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- refactor the OpenAI-backed summariser to use the official python client and keep JSON-formatted responses
- allow recordings to be uploaded, persist the latest audio path for processing, and expose a download link in the UI
- declare the OpenAI dependency so the client library is installed with the app

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1591c16148321b2ec5db384ce6a8b