### PR TITLE
feat: show summaries in text fields and auto-save

### DIFF
--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -12,6 +12,5 @@ def test_format_action_items_formats_owner():
         {"description": "Follow up with client", "owner": "Bob"},
         {"description": ""},
     ])
-    assert "Bob" in markdown
-    assert "Follow up" in markdown
+    assert "- Bob: Follow up with client" in markdown
     assert "No action" not in markdown

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -21,8 +21,11 @@ def test_serialise_segments_formats_text():
 def test_save_meeting_artifacts_writes_file(tmp_path: Path):
     transcription = build_transcription()
     summary = {"summary": "Summary text", "action_items": [{"description": "Action", "owner": "Dana"}]}
-    file_path = save_meeting_artifacts(transcription, summary, output_dir=tmp_path)
-    assert file_path.exists()
-    contents = file_path.read_text()
+    artifacts = save_meeting_artifacts(transcription, summary, output_dir=tmp_path)
+    assert artifacts.summary_path.exists()
+    assert artifacts.transcript_path.exists()
+    contents = artifacts.summary_path.read_text()
     assert "Summary text" in contents
     assert "Dana" in contents
+    transcript_contents = artifacts.transcript_path.read_text()
+    assert "Speaker 1" in transcript_contents


### PR DESCRIPTION
## Summary
- replace markdown summary display with copy-friendly text areas and surface saved files
- automatically persist meeting notes and transcripts when summarising, removing email/send controls
- allow uploading existing transcript files for summarisation and store transcripts separately

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2758aa5f88321b6c3075f3712cde3